### PR TITLE
Add PIE feature to compile umm_malloc position indipendent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,6 @@ init-if-uninitialized = ["umm-malloc-sys/init-if-uninitialized"]
 
 # Every umm_malloc function checks if the heap is initialized. If the heap is not initialized, it loops forever.
 hang-if-uninitialized = ["umm-malloc-sys/hang-if-uninitialized"]
+
+# Compile umm_malloc position indipendent.
+enable-pie = ["umm-malloc-sys/enable-pie"]

--- a/umm-malloc-sys/Cargo.toml
+++ b/umm-malloc-sys/Cargo.toml
@@ -47,3 +47,6 @@ init-if-uninitialized = []
 
 # Every umm_malloc function checks if the heap is initialized. If the heap is not initialized, it loops forever.
 hang-if-uninitialized = []
+
+# Compile umm_malloc position indipendent.
+enable-pie = []

--- a/umm-malloc-sys/build.rs
+++ b/umm-malloc-sys/build.rs
@@ -20,7 +20,14 @@ fn main() {
     }
     println!("cargo:rerun-if-changed=src/umm_malloc_cfgport.h");
 
+    // Rebuild if enable-pie feature changes
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_ENABLE_PIE");
     let mut build = cc::Build::new();
+
+    // If enable-pie feature enabled, compile it position indipendent (:
+    if env::var("CARGO_FEATURE_ENABLE_PIE").is_ok() {
+        build.flag("-fPIE");
+    }
     build
         .static_flag(true)
         .flag("-nostdlib")


### PR DESCRIPTION
Hello! Sometimes a user of this crate would want to compile it position indipendent. This will allow it (:

Feature introduced: `enable-pie`